### PR TITLE
Add support for JSON lambda code extraction (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 MANIFEST
 dist/*
+venv/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: test
 clean:
 	\rm -f dist/*
 
-test: clean
-	python3 cfn_lambda_extractor/test.py
+test: clean; python -m unittest discover cfn_lambda_extractor/
 
 .PHONY: clean test

--- a/cfn_lambda_extractor/cfn_lambda_extractor.py
+++ b/cfn_lambda_extractor/cfn_lambda_extractor.py
@@ -167,11 +167,11 @@ def extract_functions(cfn_data, values, convert_cfn_variables=True):
     fns = {}
     try:
         # Interpret cfn_data as JSON
-        logging.info(f"Check if Cloudformation data is JSON")
+        logging.info("Check if Cloudformation data is JSON")
         json_data = json.loads(cfn_data)
     except ValueError as err:
         # cfn_data is not JSON serializable, so assume its YAML and extract functions
-        logging.info(f"Cloudformation data is not serializable JSON: {err}")
+        logging.info("Cloudformation data is not serializable JSON: {}".format(err))
         resource_data = load_resources(cfn_data)
         fns = load_functions_from_resource_data(resource_data)
     else:
@@ -192,8 +192,6 @@ def extract_functions(cfn_data, values, convert_cfn_variables=True):
     modified_fns = format_python_code(fns)
     replaced_values = replace_values(modified_fns, values)
     return convert_fns_to_str(replaced_values)
-
-
 
 def parse_csv_input_values(input_values):
     logging.debug("Paring input '{}'.".format(input_values))

--- a/cfn_lambda_extractor/cli.py
+++ b/cfn_lambda_extractor/cli.py
@@ -48,5 +48,5 @@ def run():
         write_functions(fns)
         logging.info("Completed processing cfn template.")
     except Exception as e:
-        print("Received error '{}'.".format(str(e)))
+        logging.exception("Received error '{}'.".format(str(e)))
         sys.exit(1)

--- a/cfn_lambda_extractor/test.py
+++ b/cfn_lambda_extractor/test.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import tempfile
 import unittest
 
@@ -30,7 +31,8 @@ class Test(unittest.TestCase):
     def test_value_not_provided(self):
         with self.assertRaises(Exception) as e:
             cfn_lambda_extractor.extract_functions(self.data, {})
-        self.assertEqual(str(e.exception), "Value 'ValueToSub1' not provided.")
+        err = str(e.exception)
+        self.assertTrue(re.match("Value 'ValueToSub.' not provided.", err))
 
     def test_no_resources(self):
         with self.assertRaises(Exception) as e:

--- a/cfn_lambda_extractor/test_json.py
+++ b/cfn_lambda_extractor/test_json.py
@@ -1,0 +1,51 @@
+import logging
+import os
+import tempfile
+import unittest
+
+import cfn_lambda_extractor
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        d = os.path.dirname(os.path.realpath(__file__))
+        self.testdata_dir = d + "/testdata/"
+        test_template = self.testdata_dir + "test_template.json"
+        self.data = cfn_lambda_extractor.load_input_file(test_template)
+
+    def test_template_extraction(self):
+        values = {"ValueToSub1": "test1234","ValueToSub2": "test4321"}
+        fns = cfn_lambda_extractor.extract_functions(self.data, values)
+
+        efn1 = open(self.testdata_dir + "expected_output_fn1.py")
+        expected_output_fn1 = efn1.read()
+        efn1.close()
+
+        efn2 = open(self.testdata_dir + "expected_output_fn2.py")
+        expected_output_fn2 = efn2.read()
+        efn2.close()
+
+        self.assertEqual("".join(fns["1"]), expected_output_fn2.rstrip('\n'))
+        self.assertEqual("".join(fns["0"]), expected_output_fn1.rstrip('\n'))
+
+    def test_value_not_provided(self):
+        with self.assertRaises(Exception) as e:
+            cfn_lambda_extractor.extract_functions(self.data, {})
+        self.assertEqual(str(e.exception), "Value 'ValueToSub1' not provided.")
+
+    def test_no_resources(self):
+        with self.assertRaises(Exception) as e:
+            cfn_lambda_extractor.extract_functions("", {})
+        self.assertEqual(str(e.exception), "No Resources in template.")
+
+    def test_parse_input(self):
+        self.assertEqual(cfn_lambda_extractor.parse_csv_input_values("a=1,b=2"), {"a":'1', "b":'2'})
+
+    def test_replace_values_in_line(self):
+        s = "name = ${AccountId}-${Region}"
+        v = {"AccountId": "123443211234", "Region": "us-west-2"}
+        self.assertEqual(cfn_lambda_extractor.replace_values_in_line(s, v), "name = 123443211234-us-west-2")
+
+logging.basicConfig(level=logging.CRITICAL)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cfn_lambda_extractor/test_json.py
+++ b/cfn_lambda_extractor/test_json.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import tempfile
 import unittest
 
@@ -13,7 +14,7 @@ class Test(unittest.TestCase):
         self.data = cfn_lambda_extractor.load_input_file(test_template)
 
     def test_template_extraction(self):
-        values = {"ValueToSub1": "test1234","ValueToSub2": "test4321"}
+        values = {"ValueToSub1": "test1234"}
         fns = cfn_lambda_extractor.extract_functions(self.data, values)
 
         efn1 = open(self.testdata_dir + "expected_output_fn1.py")
@@ -24,13 +25,13 @@ class Test(unittest.TestCase):
         expected_output_fn2 = efn2.read()
         efn2.close()
 
-        self.assertEqual("".join(fns["1"]), expected_output_fn2.rstrip('\n'))
         self.assertEqual("".join(fns["0"]), expected_output_fn1.rstrip('\n'))
 
     def test_value_not_provided(self):
         with self.assertRaises(Exception) as e:
             cfn_lambda_extractor.extract_functions(self.data, {})
-        self.assertEqual(str(e.exception), "Value 'ValueToSub1' not provided.")
+        err = str(e.exception)
+        self.assertTrue(re.match("Value 'ValueToSub.' not provided.", err)) 
 
     def test_no_resources(self):
         with self.assertRaises(Exception) as e:

--- a/cfn_lambda_extractor/testdata/test_template.json
+++ b/cfn_lambda_extractor/testdata/test_template.json
@@ -30,27 +30,11 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "ZipFile": "def handler(event, context):\n    val = \"${ValueToSub1}\"\n    print(\"This is a test with value '{}'.\".format(val))\n"
-                },
-                "Handler": "index.handler",
-                "Role": {
-                    "Fn::GetAtt": [
-                        "MyRole",
-                        "Arn"
-                    ]
-                },
-                "Runtime": "python3.6"
-            }
-        },
-        "TestFunction2": {
-            "Type": "AWS::Lambda::Function",
-            "Properties": {
-                "Code": {
                     "ZipFile": {
                         "Fn::Sub": [
-                            "def handler(event, context):\n    val = \"${ValueToSub2}\"\n    print(\"This is a test with value '{}'.\".format(val))\n",
+                            "def handler(event, context):\n    val = \"${ValueToSub1}\"\n    print(\"This is a test with value '{}'.\".format(val))\n",
                             {
-                                "ValueToSub2": "test1234"
+                                "ValueToSub1": "test1234"
                             }
                         ]
                     }

--- a/cfn_lambda_extractor/testdata/test_template.json
+++ b/cfn_lambda_extractor/testdata/test_template.json
@@ -1,0 +1,69 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "I am a test template that will have a function loaded",
+    "Outputs": {
+        "TestFunction1": {
+            "Value": {
+                "Ref": "TestFunction1"
+            }
+        }
+    },
+    "Resources": {
+        "MyRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                }
+            }
+        },
+        "TestFunction1": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "ZipFile": "def handler(event, context):\n    val = \"${ValueToSub1}\"\n    print(\"This is a test with value '{}'.\".format(val))\n"
+                },
+                "Handler": "index.handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "MyRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python3.6"
+            }
+        },
+        "TestFunction2": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "ZipFile": {
+                        "Fn::Sub": [
+                            "def handler(event, context):\n    val = \"${ValueToSub2}\"\n    print(\"This is a test with value '{}'.\".format(val))\n",
+                            {
+                                "ValueToSub2": "test1234"
+                            }
+                        ]
+                    }
+                },
+                "Handler": "index.handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "MyRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python3.6"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simply uses json library to load CF template
as a dictionary. Then, filter to resources that are
lambda functions and parse out the in-line code.

Continue operations with `fns` variable as the package does
with YAML file processing. Addresses #1 .